### PR TITLE
Minor updates for GA readiness release

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,16 +14,9 @@ readme: README.md
 
 # Contributors
 authors:
-  - "Taylor Digilio <Taylor.Digilio@ibm.com>"
-  - "Hiren Shah <hiren@us.ibm.com>"
-  - "Aaron Kippins <amkippin@us.ibm.com>"
-  - "Yang Cao <caoy@cn.ibm.com>"
-  - "Yun Juan Yang <yunyyang@cn.ibm.com>"
-  - "Allen Zhou <xiao-yu.zhou@ibm.com>"
-  - "Xiao Zhen Zhu <zhuxiaoz@cn.ibm.com>"
-  - "Yuan Yuan <yuanyuan@cn.ibm.com>"
-  - "Qi Li <lqibj@cn.ibm.com>"
-  - "Xiao Ming Liu <xmliuxm@cn.ibm.com>"
+  - "Taylor Digilio @TaylorDigilio"
+  - "Hiren Shah @shreeji818"
+  - "Aaron Kippins @AKippins"
 
 # Description
 description: Ansible collection consisting of modules and roles to work with z/OS based on z/OS Management Facility(z/OSMF).
@@ -66,7 +59,7 @@ issues: https://github.com/IBM/ibm_zosmf/issues
 
 # Ignore files and directories matching the following patterns
 build_ignore:
-  - Jenkinsfile
+  - Jenkinsfile*
   - ansible.cfg
   - .gitignore
   - .github
@@ -86,3 +79,7 @@ build_ignore:
   - tests/sanity/ignore-2.14.txt
   - .idea
   - meta/context
+  - changelogs
+  - importer_result.json
+  - tests/output
+  - tests/scripts

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -2,4 +2,3 @@ plugins/modules/zmf_authenticate.py validate-modules:missing-gplv3-license # Lic
 plugins/modules/zmf_workflow.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
 plugins/modules/zmf_workflow.py validate-modules:no-log-needed # Ignore no-log-needed check for workflow_key
 plugins/modules/zmf_sca.py validate-modules:missing-gplv3-license # Licensed under Apache 2.0
-docs/scripts/auto-doc-gen.sh shebang!skip # Documentation generation script


### PR DESCRIPTION
Galaxy.yml
- Updated to use GH IDs over emails
- Removed contributors no longer contributing (those authors are still in source code and should remain there) but for galaxy.yml we can update to the active maintainer list

tests/sanity/ignore-2.20.txt:
- Removed shebang entry, not needed, its been tested and validated by me , see output for validation.

```
$ (venv-2.18)ansible-galaxy collection install git+https://github.com/IBM/ibm_zosmf.git,ddimatos-fixes-to-amkippin

Installing 'ibm.ibm_zosmf:1.6.0' to '/Users/ddimatos/git/ghe/ibm_zos_core/venv/venv-2.18/ansible_collections/ibm/ibm_zosmf'
Created collection for ibm.ibm_zosmf:1.6.0 at /Users/ddimatos/git/ghe/ibm_zos_core/venv/venv-2.18/ansible_collections/ibm/ibm_zosmf
ibm.ibm_zosmf:1.6.0 was installed successfully
```

```
$ (venv-2.18) ansible-galaxy collection list
```

```
# /Users/ddimatos/git/ghe/ibm_zos_core/venv/venv-2.18/ansible_collections
Collection           Version
-------------------- -------
.git.hooks           *
.git.info            *
.git.objects         *
.git.refs            *
ddimatos.zos_modules 1.0.0
ibm.ibm_zos_core     1.13.1
ibm.ibm_zosmf        1.6.0
```

```
$ (venv-2.18) ansible-test sanity --requirements --docker default
Starting new "ansible-test-controller-AnIiyYw8" container.
Adding "ansible-test-controller-AnIiyYw8" to container database.
Bootstrapping Python 3.13 at: /usr/bin/python3.13
Running sanity test "action-plugin-docs"
Running sanity test "ansible-doc"
Running sanity test "changelog"
Running sanity test "compile" on Python 3.8
Running sanity test "compile" on Python 3.9
Running sanity test "compile" on Python 3.10
Running sanity test "compile" on Python 3.11
Running sanity test "compile" on Python 3.12
Running sanity test "compile" on Python 3.13
Running sanity test "empty-init"
Running sanity test "ignores"
Running sanity test "import" on Python 3.8
Running sanity test "import" on Python 3.9
Running sanity test "import" on Python 3.10
Running sanity test "import" on Python 3.11
Running sanity test "import" on Python 3.12
Running sanity test "import" on Python 3.13
Running sanity test "line-endings"
Running sanity test "no-assert"
Running sanity test "no-get-exception"
Running sanity test "no-illegal-filenames"
Running sanity test "no-smart-quotes"
Running sanity test "pep8"
Running sanity test "pslint"
Running sanity test "pylint"
Running sanity test "replace-urlopen"
Running sanity test "runtime-metadata"
Running sanity test "shebang"
Running sanity test "shellcheck"
Running sanity test "symlinks"
Running sanity test "use-argspec-type-path"
Running sanity test "use-compat-six"
Running sanity test "validate-modules"
Running sanity test "yamllint"
```

```
$ (venv-2.18) ansible-lint -c .ansible-lint --profile production
Passed: 0 failure(s), 0 warning(s) on 135 files. Profile 'production' was required, and it passed.
A new release of ansible-lint is available: 24.7.0 → 26.1.1 Upgrade by running: pip install --upgrade ansible-lint
```
